### PR TITLE
missing noexcept keyword for clang

### DIFF
--- a/Source/Shared/arcana/expected.h
+++ b/Source/Shared/arcana/expected.h
@@ -69,10 +69,25 @@ namespace arcana
     class bad_expected_access : public std::exception
     {
     public:
-        const char* what() const override
+        const char* what() const noexcept override
         {
             return "tried accessing value()/error() of an expected when it wasn't set";
         }
+    };
+
+    class exception_with_reason : public std::exception
+    {
+    public:
+        exception_with_reason(const char* reason)
+            : m_reason(reason)
+        {}
+
+        const char* what() const noexcept override
+        {
+            return m_reason.c_str();
+        }
+    private:
+        std::string m_reason;
     };
 
     template<typename E>

--- a/Source/Shared/arcana/expected.h
+++ b/Source/Shared/arcana/expected.h
@@ -75,21 +75,6 @@ namespace arcana
         }
     };
 
-    class exception_with_reason : public std::exception
-    {
-    public:
-        exception_with_reason(const char* reason)
-            : m_reason(reason)
-        {}
-
-        const char* what() const noexcept override
-        {
-            return m_reason.c_str();
-        }
-    private:
-        std::string m_reason;
-    };
-
     template<typename E>
     class unexpected
     {

--- a/Source/Shared/arcana/expected.h
+++ b/Source/Shared/arcana/expected.h
@@ -413,7 +413,7 @@ namespace arcana
     template<typename Left, typename Right>
     struct largest_error
     {
-        using type = typename typename largest_integral_constant<error_priority<Left>, error_priority<Right>>::type::type;
+        using type = typename largest_integral_constant<error_priority<Left>, error_priority<Right>>::type::type;
     };
 
     namespace internal


### PR DESCRIPTION
missing noexcept keyword for clang
added exception_with_reason that supports an info string at construction