### PR TITLE
Fix issues with run_loop_scheduler

### DIFF
--- a/Source/Apple/arcana/threading/task_schedulers.h
+++ b/Source/Apple/arcana/threading/task_schedulers.h
@@ -46,6 +46,8 @@ namespace arcana
             CFRunLoopPerformBlock(m_runLoop, kCFRunLoopCommonModes, ^{
                 _callable();
             });
+            
+            // In case the run loop is idle, we need to wake it up and drain the queue
             CFRunLoopWakeUp(m_runLoop);
         }
 

--- a/Source/Apple/arcana/threading/task_schedulers.h
+++ b/Source/Apple/arcana/threading/task_schedulers.h
@@ -43,9 +43,10 @@ namespace arcana
         void operator()(CallableT&& callable) const
         {
             CallableT _callable{ std::forward<CallableT>(callable) };
-            CFRunLoopPerformBlock(m_runLoop, kCFRunLoopDefaultMode, ^{
+            CFRunLoopPerformBlock(m_runLoop, kCFRunLoopCommonModes, ^{
                 _callable();
             });
+            CFRunLoopWakeUp(m_runLoop);
         }
 
         static run_loop_scheduler get_for_current_thread()


### PR DESCRIPTION
We found a couple of problems with the `run_loop_scheduler` when used in the context of React Native (but these are problems in general).

1. Work queued into a CFRunLoop is not necessarily automatically dequeued and run. Something needs to "wake up" the run loop thread and tell it to process pending work. Without an explicit call to `CFRunLoopWakeUp`, we are depending on someone else happening to call that. In the context of Babylon React Native, this was happening through other operations on the JS thread (in the demo app, it was specifically updates happening between the UI thread and JS thread to update the FPS counter, such that if the FPS counter was turned off, the scene stopped rendering because the `CFRunLoop` stopped dequeuing pending operations because no one was calling `CFRunLoopWakeUp`). We should call this explicitly every time we queue work in the `CFRunLoop` since this is the purpose of the scheduler.
2. Scheduling with `kCFRunLoopDefaultMode` can cause our queued operations to be starved if higher priority operations are queued. Scheduling with `kCFRunLoopCommonModes` ensures that our queued work is treated fairly with most other scheduled work, preventing possible starvation.

For another example of using the `CFRunLoop` in this way, see https://github.com/facebook/react-native/blob/d0871d0a9a373e1d3ac35da46c85c0d0e793116d/React/CxxBridge/RCTMessageThread.mm#L47