### PR TITLE
Added lazy type.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,8 @@ set(SOURCES ${SOURCES}
     "Source/Shared/arcana/containers/ticketed_collection.h"
     "Source/Shared/arcana/containers/unique_vector.h"
     "Source/Shared/arcana/containers/unordered_bimap.h"
-    "Source/Shared/arcana/containers/weak_table.h")
+    "Source/Shared/arcana/containers/weak_table.h"
+    "Source/Shared/arcana/containers/lazy.h")
 
 # experimental
 set(SOURCES ${SOURCES}

--- a/Source/Shared/arcana/containers/lazy.h
+++ b/Source/Shared/arcana/containers/lazy.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <memory>
+#include <tuple>
+
+namespace arcana
+{
+    template<typename T, typename... Ts>
+    class lazy
+    {
+    public:
+        lazy(Ts... args)
+            : m_args{std::make_unique<std::tuple<Ts...>>(std::make_tuple(std::move(args)...))}
+        {
+        }
+
+        operator T&()
+        {
+            if (m_value == nullptr)
+            {
+                auto initializer = [this](Ts... args) { m_value = std::make_unique<T>(std::move(args)...); };
+                std::apply(initializer, *m_args);
+                m_args.reset();
+            }
+
+            return *m_value;
+        }
+
+    private:
+        std::unique_ptr<T> m_value{};
+        std::unique_ptr<std::tuple<Ts...>> m_args{};
+    };
+
+    template<typename T, typename... Ts>
+    lazy<T, Ts...> make_lazy(Ts... args)
+    {
+        return {std::move(args)...};
+    }
+}


### PR DESCRIPTION
A use case came up for this while fixing a Babylon Native bug where an XR-related global needs to be lazily instantiated (or some alternative) so that it's never created on computers that don't have an OpenXR runtime. We can do without this -- the precipitating issue is small enough to be gracefully handled with a bespoke implementation -- but lazy evaluation is a common enough pattern that I was actually a little surprised there doesn't appear to be an STL type for this (there's an experimental one in Rust, but I didn't see one in C++).

Note: If we decide we actually want this, a little more thought will need to be given to things like implicit constructors and copyability. This draft is just to propose the type and discuss if it's something we think is worth having.