### PR TITLE
No destroy cancellation none

### DIFF
--- a/Source/Shared/arcana/threading/cancellation.h
+++ b/Source/Shared/arcana/threading/cancellation.h
@@ -129,9 +129,24 @@ namespace arcana
         std::atomic<bool> m_cancellationRequested{ false };
     };
 
+    namespace internal::cancellation_impl
+    {
+        template <class T>
+        class no_destroy
+        {
+            alignas(T) unsigned char data_[sizeof(T)];
+        public:
+            template <class... Ts> no_destroy(Ts&&... ts)
+            { new (data_) T(std::forward<Ts>(ts)...); }
+
+            T &get() { return *reinterpret_cast<T *>(data_); }
+        };
+
+        inline no_destroy<cancellation_source> none{};
+    }
+
     inline cancellation& cancellation::none()
     {
-        static cancellation_source n{};
-        return n;
+        return internal::cancellation_impl::none.get();
     }
 }

--- a/Source/Shared/arcana/threading/cancellation.h
+++ b/Source/Shared/arcana/threading/cancellation.h
@@ -129,17 +129,27 @@ namespace arcana
         std::atomic<bool> m_cancellationRequested{ false };
     };
 
-    namespace internal::cancellation_impl
+    namespace internal::no_destroy_cancellation
     {
+        // To address a problem with static globals recognized as the same as in a 
+        // standards proposal, we adopt a workaround described in the proposal.
+        // http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p1247r0.html
         template <class T>
         class no_destroy
         {
             alignas(T) unsigned char data_[sizeof(T)];
-        public:
-            template <class... Ts> no_destroy(Ts&&... ts)
-            { new (data_) T(std::forward<Ts>(ts)...); }
 
-            T &get() { return *reinterpret_cast<T *>(data_); }
+        public:
+            template <class... Ts>
+            no_destroy(Ts&&... ts)
+            {
+                new (data_)T(std::forward<Ts>(ts)...);
+            }
+
+            T &get()
+            {
+                return *reinterpret_cast<T *>(data_);
+            }
         };
 
         inline no_destroy<cancellation_source> none{};
@@ -147,6 +157,6 @@ namespace arcana
 
     inline cancellation& cancellation::none()
     {
-        return internal::cancellation_impl::none.get();
+        return internal::no_destroy_cancellation::none.get();
     }
 }


### PR DESCRIPTION
This change addresses a problem we were encountering in Babylon Native where `cancellation::none` was getting torn down by one thread while another thread still needed it to exist. A proposal, referenced in a comment in the code, exists to standardize a mechanism for handling this type of error:

http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p1247r0.html

However, since this proposal is not yet standard, I instead adopted one of the alternatives listed in the proposal to resolve this problem for now. This change has been tested and confirmed to solve the problem Babylon Native was exhibiting.