### PR TITLE
Downgrading min CMake version to 3.10.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.10.2)
 
 project(arcana.cpp)
 


### PR DESCRIPTION
Arcana works with CMake 3.10.2 as well.
So bringing down the min CMake version required.