### PR TITLE
Rethrow unhandled errors

### DIFF
--- a/Source/Shared/arcana/threading/internal/internal_task.h
+++ b/Source/Shared/arcana/threading/internal/internal_task.h
@@ -212,7 +212,7 @@ namespace arcana
                 {
                     for (auto& continuation : continuations)
                         continuation.run();
-                    m_continued = true;
+                    m_continued = continuations.size() > 0;
                 }
             }
 


### PR DESCRIPTION
Change behavior of returning payloads to rethrow unhandled errors -- that is, errors which remain on a dying payload which has never executed a continuation. Open questions remain about how this functionality relates to teardown and/or cancellation.