### PR TITLE
Add performance tracing abstraction

### DIFF
--- a/Source/Android/arcana/tracing/trace_region.h
+++ b/Source/Android/arcana/tracing/trace_region.h
@@ -12,21 +12,20 @@ namespace arcana
     {
     public:
         trace_region() = delete;
-        trace_region& operator=(const trace_region&) = delete;
         trace_region(const trace_region&) = delete;
-        trace_region& operator=(trace_region&&) = delete;
+        trace_region& operator=(const trace_region&) = delete;
 
         trace_region(const char*)
         {
         }
 
-        trace_region(trace_region&&)
-        {
-        }
+        trace_region(trace_region&&) = default;
 
         ~trace_region()
         {
         }
+
+        trace_region& operator=(trace_region&&) = default;
 
         static void enable()
         {

--- a/Source/Android/arcana/tracing/trace_region.h
+++ b/Source/Android/arcana/tracing/trace_region.h
@@ -1,0 +1,39 @@
+//
+// Copyright (C) Microsoft Corporation. All rights reserved.
+//
+
+#pragma once
+
+namespace arcana
+{
+    // TODO: https://developer.android.com/topic/performance/tracing/custom-events-native
+    //       https://developer.android.com/ndk/reference/group/tracing
+    class trace_region final
+    {
+    public:
+        trace_region() = delete;
+        trace_region& operator=(const trace_region&) = delete;
+        trace_region(const trace_region&) = delete;
+        trace_region& operator=(trace_region&&) = delete;
+
+        trace_region(const char*)
+        {
+        }
+
+        trace_region(trace_region&& other)
+        {
+        }
+
+        ~trace_region()
+        {
+        }
+
+        static void enable()
+        {
+        }
+
+        static void disable()
+        {
+        }
+    };
+}

--- a/Source/Android/arcana/tracing/trace_region.h
+++ b/Source/Android/arcana/tracing/trace_region.h
@@ -20,7 +20,7 @@ namespace arcana
         {
         }
 
-        trace_region(trace_region&& other)
+        trace_region(trace_region&&)
         {
         }
 

--- a/Source/Apple/arcana/tracing/trace_region.h
+++ b/Source/Apple/arcana/tracing/trace_region.h
@@ -1,0 +1,57 @@
+//
+// Copyright (C) Microsoft Corporation. All rights reserved.
+//
+
+#pragma once
+
+#include <os/signpost.h>
+
+namespace arcana
+{
+    class trace_region final
+    {
+    public:
+        trace_region() = delete;
+        trace_region& operator=(const trace_region&) = delete;
+        trace_region(const trace_region&) = delete;
+        trace_region& operator=(trace_region&&) = delete;
+
+        trace_region(const char* name) :
+            m_id{s_enabled ? os_signpost_id_generate(s_log) : OS_SIGNPOST_ID_NULL}
+        {
+            if (m_id != OS_SIGNPOST_ID_NULL)
+            {
+                os_signpost_interval_begin(s_log, m_id, "trace_region", "%s", name);
+            }
+        }
+
+        trace_region(trace_region&& other) :
+            m_id{other.m_id}
+        {
+            other.m_id = OS_SIGNPOST_ID_NULL;
+        }
+
+        ~trace_region()
+        {
+            if (m_id != OS_SIGNPOST_ID_NULL)
+            {
+                os_signpost_interval_end(s_log, m_id, "trace_region");
+            }
+        }
+
+        static void enable()
+        {
+            s_enabled = true;
+        }
+
+        static void disable()
+        {
+            s_enabled = false;
+        }
+
+    private:
+        static inline std::atomic<bool> s_enabled{false};
+        static inline os_log_t s_log{os_log_create("arcana", OS_LOG_CATEGORY_POINTS_OF_INTEREST)};
+        os_signpost_id_t m_id;
+    };
+}

--- a/Source/Apple/arcana/tracing/trace_region.h
+++ b/Source/Apple/arcana/tracing/trace_region.h
@@ -6,22 +6,23 @@
 
 #include <os/signpost.h>
 
+#define SIGNPOST_NAME "trace_region"
+
 namespace arcana
 {
     class trace_region final
     {
     public:
         trace_region() = delete;
-        trace_region& operator=(const trace_region&) = delete;
         trace_region(const trace_region&) = delete;
-        trace_region& operator=(trace_region&&) = delete;
+        trace_region& operator=(const trace_region&) = delete;
 
         trace_region(const char* name) :
             m_id{s_enabled ? os_signpost_id_generate(s_log) : OS_SIGNPOST_ID_NULL}
         {
             if (m_id != OS_SIGNPOST_ID_NULL)
             {
-                os_signpost_interval_begin(s_log, m_id, "trace_region", "%s", name);
+                os_signpost_interval_begin(s_log, m_id, SIGNPOST_NAME, "%s", name);
             }
         }
 
@@ -35,8 +36,21 @@ namespace arcana
         {
             if (m_id != OS_SIGNPOST_ID_NULL)
             {
-                os_signpost_interval_end(s_log, m_id, "trace_region");
+                os_signpost_interval_end(s_log, m_id, SIGNPOST_NAME);
             }
+        }
+
+        trace_region& operator=(trace_region&& other)
+        {
+            if (m_id != OS_SIGNPOST_ID_NULL)
+            {
+                os_signpost_interval_end(s_log, m_id, SIGNPOST_NAME);
+            }
+
+            m_id = other.m_id;
+            other.m_id = OS_SIGNPOST_ID_NULL;
+
+            return *this;
         }
 
         static void enable()

--- a/Source/Unix/arcana/tracing/trace_region.h
+++ b/Source/Unix/arcana/tracing/trace_region.h
@@ -1,0 +1,38 @@
+//
+// Copyright (C) Microsoft Corporation. All rights reserved.
+//
+
+#pragma once
+
+namespace arcana
+{
+    // TODO
+    class trace_region final
+    {
+    public:
+        trace_region() = delete;
+        trace_region& operator=(const trace_region&) = delete;
+        trace_region(const trace_region&) = delete;
+        trace_region& operator=(trace_region&&) = delete;
+
+        trace_region(const char*)
+        {
+        }
+
+        trace_region(trace_region&& other)
+        {
+        }
+
+        ~trace_region()
+        {
+        }
+
+        static void enable()
+        {
+        }
+
+        static void disable()
+        {
+        }
+    };
+}

--- a/Source/Unix/arcana/tracing/trace_region.h
+++ b/Source/Unix/arcana/tracing/trace_region.h
@@ -19,7 +19,7 @@ namespace arcana
         {
         }
 
-        trace_region(trace_region&& other)
+        trace_region(trace_region&&)
         {
         }
 

--- a/Source/Unix/arcana/tracing/trace_region.h
+++ b/Source/Unix/arcana/tracing/trace_region.h
@@ -11,21 +11,20 @@ namespace arcana
     {
     public:
         trace_region() = delete;
-        trace_region& operator=(const trace_region&) = delete;
         trace_region(const trace_region&) = delete;
-        trace_region& operator=(trace_region&&) = delete;
+        trace_region& operator=(const trace_region&) = delete;
 
         trace_region(const char*)
         {
         }
 
-        trace_region(trace_region&&)
-        {
-        }
+        trace_region(trace_region&&) = default;
 
         ~trace_region()
         {
         }
+
+        trace_region& operator=(trace_region&&) = default;
 
         static void enable()
         {

--- a/Source/Windows/arcana/tracing/trace_region.h
+++ b/Source/Windows/arcana/tracing/trace_region.h
@@ -1,0 +1,38 @@
+//
+// Copyright (C) Microsoft Corporation. All rights reserved.
+//
+
+#pragma once
+
+namespace arcana
+{
+    // TODO: https://docs.microsoft.com/en-us/windows/win32/tracelogging/tracelogging-native-quick-start
+    class trace_region final
+    {
+    public:
+        trace_region() = delete;
+        trace_region& operator=(const trace_region&) = delete;
+        trace_region(const trace_region&) = delete;
+        trace_region& operator=(trace_region&&) = delete;
+
+        trace_region(const char*)
+        {
+        }
+
+        trace_region(trace_region&& other)
+        {
+        }
+
+        ~trace_region()
+        {
+        }
+
+        static void enable()
+        {
+        }
+
+        static void disable()
+        {
+        }
+    };
+}

--- a/Source/Windows/arcana/tracing/trace_region.h
+++ b/Source/Windows/arcana/tracing/trace_region.h
@@ -19,7 +19,7 @@ namespace arcana
         {
         }
 
-        trace_region(trace_region&& other)
+        trace_region(trace_region&&)
         {
         }
 

--- a/Source/Windows/arcana/tracing/trace_region.h
+++ b/Source/Windows/arcana/tracing/trace_region.h
@@ -11,21 +11,20 @@ namespace arcana
     {
     public:
         trace_region() = delete;
-        trace_region& operator=(const trace_region&) = delete;
         trace_region(const trace_region&) = delete;
-        trace_region& operator=(trace_region&&) = delete;
+        trace_region& operator=(const trace_region&) = delete;
 
         trace_region(const char*)
         {
         }
 
-        trace_region(trace_region&&)
-        {
-        }
+        trace_region(trace_region&&) = default;
 
         ~trace_region()
         {
         }
+
+        trace_region& operator=(trace_region&&) = default;
 
         static void enable()
         {


### PR DESCRIPTION
This is intended to be a light weight mechanism to perform a performance trace interval. The implementation will be different per platform, and so far I've only implemented it for Apple. Ideally they would all share a header to ensure the contract is identical across platforms, but I'm not sure how to do this in way that is both header only and the implementations are per platform. Open to suggestions on this.