### PR TITLE
Uncopyable work queue

### DIFF
--- a/Source/Shared/arcana/functional/inplace_function.h
+++ b/Source/Shared/arcana/functional/inplace_function.h
@@ -35,23 +35,13 @@
 namespace stdext
 {
     constexpr size_t InplaceFunctionDefaultCapacity = 32;
-        
-    template<bool SupportsCopy>
+
     struct inplace_function_operation
     {
         enum class operations_enum
         {
             Destroy,
             Copy,
-            Move
-        };
-    };
-    template<>
-    struct inplace_function_operation<false>
-    {
-        enum class operations_enum
-        {
-            Destroy,
             Move
         };
     };
@@ -62,8 +52,8 @@ namespace stdext
              bool Copyable = true>
     class /*alignas(Alignment)*/ inplace_function;
 
-    template<typename RetT, typename... ArgsT, size_t Capacity, size_t Alignment, bool Copyable>
-    class /*alignas(Alignment)*/ inplace_function<RetT(ArgsT...), Capacity, Alignment, Copyable>
+    template<typename RetT, typename... ArgsT, size_t Capacity, size_t Alignment>
+    class /*alignas(Alignment)*/ inplace_function<RetT(ArgsT...), Capacity, Alignment, true>
     {
     public:
         template<typename SignatureT2, std::size_t Capacity2, std::size_t Alignment2, bool Copyable2>
@@ -89,8 +79,6 @@ namespace stdext
         template<typename CallableT>
         inplace_function(const CallableT& c)
         {
-            static_assert(!Copyable || std::is_copy_constructible<CallableT>::value, 
-                "Cannot create a copyable inplace function from a non-copyable callable.");
             this->set(c);
         }
 
@@ -100,8 +88,6 @@ namespace stdext
         template<typename CallableT, class = typename std::enable_if<!std::is_lvalue_reference<CallableT>::value>::type>
         inplace_function(CallableT&& c)
         {
-            static_assert(!Copyable || std::is_copy_constructible<CallableT>::value, 
-                "Cannot create a copyable inplace function from a non-copyable callable.");
             this->set(std::move(c));
         }
 
@@ -109,7 +95,6 @@ namespace stdext
         // May throw any exception encountered by the constructor when copying the target object
         inplace_function(const inplace_function& other)
         {
-            static_assert(Copyable, "Cannot copy-construct from a non-copyable inplace function.");
             this->copy(other);
         }
 
@@ -142,11 +127,340 @@ namespace stdext
         // May throw any exception encountered by the assignment operator when copying the target object
         inplace_function& operator=(const inplace_function& other)
         {
-            static_assert(Copyable, "Cannot copy-assign from a non-copyable inplace function");
             this->clear();
             this->copy(other);
             return *this;
         }
+
+        // Assigns the other’s target by way of moving
+        // May throw any exception encountered by the assignment operator when moving the target object
+        inplace_function& operator=(inplace_function&& other)
+        {
+            this->clear();
+            this->move(std::move(other));
+            return *this;
+        }
+
+        // Allows for copy assignment of an inplace_function object of the same type, but with a smaller buffer
+        // If the copy constructor of target object throws, this is left in uninitialized state
+        // If OtherCapacity is greater than Capacity, a compile-time error is issued
+        template<size_t OtherCapacity, size_t OtherAlignment>
+        inplace_function& operator=(const inplace_function<RetT(ArgsT...), OtherCapacity, OtherAlignment, true>& other)
+        {
+            this->clear();
+            this->copy(other);
+            return *this;
+        }
+
+        // Allows for move assignment of an inplace_function object of the same type, but with a smaller buffer
+        // If the move constructor of target object throws, this is left in uninitialized state
+        // If OtherCapacity is greater than Capacity, a compile-time error is issued
+        template<size_t OtherCapacity, size_t OtherAlignment>
+        inplace_function& operator=(inplace_function<RetT(ArgsT...), OtherCapacity, OtherAlignment>&& other)
+        {
+            this->clear();
+            this->move(std::move(other));
+            return *this;
+        }
+
+        // Assign a new target
+        // If the copy constructor of target object throws, this is left in uninitialized state
+        template<typename CallableT, class = typename std::enable_if<!std::is_lvalue_reference<CallableT>::value>::type>
+        inplace_function& operator=(const CallableT& target)
+        {
+            this->clear();
+            this->set(target);
+            return *this;
+        }
+
+        // Assign a new target by way of moving
+        // If the move constructor of target object throws, this is left in uninitialized state
+        template<typename Callable>
+        inplace_function& operator=(Callable&& target)
+        {
+            this->clear();
+            this->set(std::move(target));
+            return *this;
+        }
+
+        // Compares this inplace function with a null pointer
+        // Empty functions compare equal, non-empty functions compare unequal
+        bool operator==(std::nullptr_t)
+        {
+            return !operator bool();
+        }
+
+        // Compares this inplace function with a null pointer
+        // Empty functions compare equal, non-empty functions compare unequal
+        bool operator!=(std::nullptr_t)
+        {
+            return operator bool();
+        }
+
+        // Converts to 'true' if assigned
+        explicit operator bool() const throw()
+        {
+            return m_InvokeFctPtr != &DefaultFunction;
+        }
+
+        // Invokes the target
+        // Throws std::bad_function_call if not assigned
+        RetT operator()(ArgsT... args) const
+        {
+            return m_InvokeFctPtr(std::forward<ArgsT>(args)..., data());
+        }
+
+        // Swaps two targets
+        void swap(inplace_function& other)
+        {
+            BufferType tempData;
+            this->move(m_Data, tempData);
+            other.move(other.m_Data, m_Data);
+            this->move(tempData, other.m_Data);
+            std::swap(m_InvokeFctPtr, other.m_InvokeFctPtr);
+            std::swap(m_ManagerFctPtr, other.m_ManagerFctPtr);
+        }
+
+    private:
+        using BufferType = typename std::aligned_storage<Capacity, Alignment>::type;
+        void clear()
+        {
+            m_InvokeFctPtr = &DefaultFunction;
+            if (m_ManagerFctPtr)
+                m_ManagerFctPtr(data(), nullptr, Operation::Destroy);
+            m_ManagerFctPtr = nullptr;
+        }
+
+        template<size_t OtherCapacity, size_t OtherAlignment>
+        void copy(const inplace_function<RetT(ArgsT...), OtherCapacity, OtherAlignment, true>& other)
+        {
+            static_assert(OtherCapacity <= Capacity, "Can't squeeze larger inplace_function into a smaller one");
+            static_assert(Alignment % OtherAlignment == 0, "Incompatible alignments");
+
+            if (other.m_ManagerFctPtr)
+                other.m_ManagerFctPtr(data(), other.data(), Operation::Copy);
+
+            m_InvokeFctPtr = other.m_InvokeFctPtr;
+            m_ManagerFctPtr = other.m_ManagerFctPtr;
+        }
+
+        void move(BufferType& from, BufferType& to)
+        {
+            if (m_ManagerFctPtr)
+                m_ManagerFctPtr(&from, &to, Operation::Move);
+            else
+                to = from;
+        }
+
+        template<size_t OtherCapacity, size_t OtherAlignment, bool OtherCopyable>
+        void move(inplace_function<RetT(ArgsT...), OtherCapacity, OtherAlignment, OtherCopyable>&& other)
+        {
+            static_assert(OtherCapacity <= Capacity, "Can't squeeze larger inplace_function into a smaller one");
+            static_assert(Alignment % OtherAlignment == 0, "Incompatible alignments");
+            static_assert(OtherCopyable, "Cannot move an uncopyable inplace_function into a copyable one");
+
+            if (other.m_ManagerFctPtr)
+                other.m_ManagerFctPtr(data(), other.data(), Operation::Move);
+
+            m_InvokeFctPtr = other.m_InvokeFctPtr;
+            m_ManagerFctPtr = other.m_ManagerFctPtr;
+
+            other.m_InvokeFctPtr = &DefaultFunction;
+            // don't reset the others management function
+            // because it still needs to destroy the lambda its holding.
+        }
+
+        void* data()
+        {
+            return &m_Data;
+        }
+        const void* data() const
+        {
+            return &m_Data;
+        }
+
+        using CompatibleFunctionPointer = RetT (*)(ArgsT...);
+        using InvokeFctPtrType = RetT (*)(ArgsT..., const void* thisPtr);
+        using Operation = inplace_function_operation::operations_enum;
+        using ManagerFctPtrType = void (*)(void* thisPtr, const void* fromPtr, Operation);
+
+        InvokeFctPtrType m_InvokeFctPtr;
+        ManagerFctPtrType m_ManagerFctPtr;
+
+        BufferType m_Data;
+
+        static RetT DefaultFunction(ArgsT..., const void*)
+        {
+            throw std::bad_function_call();
+        }
+
+        void set(std::nullptr_t)
+        {
+            m_ManagerFctPtr = nullptr;
+            m_InvokeFctPtr = &DefaultFunction;
+        }
+
+        // For function pointers
+        void set(CompatibleFunctionPointer ptr)
+        {
+            // this is dodgy, and - according to standard - undefined behaviour. But it works
+            // see: http://stackoverflow.com/questions/559581/casting-a-function-pointer-to-another-type
+            m_ManagerFctPtr = nullptr;
+            m_InvokeFctPtr = reinterpret_cast<InvokeFctPtrType>(ptr);
+        }
+
+        // Set - for functors
+        // enable_if makes sure this is excluded for function references and pointers.
+        template<typename FunctorArgT>
+        typename std::enable_if<!std::is_pointer<FunctorArgT>::value && !std::is_function<FunctorArgT>::value>::type
+        set(const FunctorArgT& ftor)
+        {
+            using FunctorT = typename std::remove_reference<FunctorArgT>::type;
+            static_assert(sizeof(FunctorT) <= Capacity, "Functor too big to fit in the buffer");
+            static_assert(Alignment % alignof(FunctorArgT) == 0, "Incompatible alignment");
+
+            // copy functor into the mem buffer
+            FunctorT* buffer = reinterpret_cast<FunctorT*>(&m_Data);
+            new (buffer) FunctorT(ftor);
+
+            // generate destructor, copy-constructor and move-constructor
+            m_ManagerFctPtr = &manage_function<FunctorT>::call;
+
+            // generate entry call
+            m_InvokeFctPtr = &invoke<FunctorT>;
+        }
+
+        // Set - for functors
+        // enable_if makes sure this is excluded for function references and pointers.
+        template<typename FunctorArgT>
+        typename std::enable_if<!std::is_pointer<FunctorArgT>::value && !std::is_function<FunctorArgT>::value>::type
+        set(FunctorArgT&& ftor)
+        {
+            using FunctorT = typename std::remove_reference<FunctorArgT>::type;
+            static_assert(sizeof(FunctorT) <= Capacity, "Functor too big to fit in the buffer");
+            static_assert(Alignment % alignof(FunctorArgT) == 0, "Incompatible alignment");
+
+            // copy functor into the mem buffer
+            FunctorT* buffer = reinterpret_cast<FunctorT*>(&m_Data);
+            new (buffer) FunctorT(std::move(ftor));
+
+            // generate destructor, copy-constructor and move-constructor
+            m_ManagerFctPtr = &manage_function<FunctorT>::call;
+
+            // generate entry call
+            m_InvokeFctPtr = &invoke<FunctorT>;
+        }
+
+        template<typename FunctorT>
+        static RetT invoke(ArgsT... args, const void* dataPtr)
+        {
+            FunctorT* functor = (FunctorT*)const_cast<void*>(dataPtr);
+            return (*functor)(std::forward<ArgsT>(args)...);
+        }
+
+        template<typename FunctorT>
+        struct manage_function
+        {
+            static void call(void* dataPtr, const void* fromPtr, Operation op)
+            {
+                FunctorT* thisFunctor = reinterpret_cast<FunctorT*>(dataPtr);
+                switch (op)
+                {
+                    case Operation::Copy:
+                    {
+                        const FunctorT* source = (const FunctorT*)const_cast<void*>(fromPtr);
+                        new (thisFunctor) FunctorT(*source);
+                        break;
+                    }
+                    case Operation::Destroy:
+                    {
+                        thisFunctor->~FunctorT();
+                        break;
+                    }
+                    case Operation::Move:
+                    {
+                        FunctorT* source = (FunctorT*)fromPtr;
+                        new (thisFunctor) FunctorT(std::move(*source));
+                        break;
+                    }
+                    default:
+                    {
+                        assert(false && "Unexpected operation");
+                    }
+                }
+            }
+        };
+    };
+
+    template<typename RetT, typename... ArgsT, size_t Capacity, size_t Alignment>
+    class /*alignas(Alignment)*/ inplace_function<RetT(ArgsT...), Capacity, Alignment, false>
+    {
+    public:
+        template<typename SignatureT2, std::size_t Capacity2, std::size_t Alignment2, bool Copyable2>
+        friend class inplace_function;
+
+        // TODO create free operator overloads, to handle switched arguments
+
+        // Creates and empty inplace_function
+        inplace_function()
+            : m_InvokeFctPtr(&DefaultFunction)
+            , m_ManagerFctPtr(nullptr)
+        {}
+
+        // Destroys the inplace_function. If the stored callable is valid, it is destroyed also
+        ~inplace_function()
+        {
+            this->clear();
+        }
+
+        // Creates an implace function, copying the target of other within the internal buffer
+        // If the callable is larger than the internal buffer, a compile-time error is issued
+        // May throw any exception encountered by the constructor when copying the target object
+        template<typename CallableT>
+        inplace_function(const CallableT& c)
+        {
+            this->set(c);
+        }
+
+        // Moves the target of an implace function, storing the callable within the internal buffer
+        // If the callable is larger than the internal buffer, a compile-time error is issued
+        // May throw any exception encountered by the constructor when moving the target object
+        template<typename CallableT, class = typename std::enable_if<!std::is_lvalue_reference<CallableT>::value>::type>
+        inplace_function(CallableT&& c)
+        {
+            this->set(std::move(c));
+        }
+
+        // Copy construction is not possible from uncopyable inplace_functions.
+        inplace_function(const inplace_function& other) = delete;
+
+        // Move construct an implace_function, moving the other’s target to this inplace_function’s internal buffer
+        // May throw any exception encountered by the constructor when moving the target object
+        inplace_function(inplace_function&& other)
+        {
+            this->move(std::move(other));
+        }
+
+        // Allows for copying from inplace_function object of the same type, but with a smaller buffer
+        // May throw any exception encountered by the constructor when copying the target object
+        // If OtherCapacity is greater than Capacity, a compile-time error is issued
+        template<size_t OtherCapacity, size_t OtherAlignment>
+        inplace_function(const inplace_function<RetT(ArgsT...), OtherCapacity, OtherAlignment, true>& other)
+        {
+            this->copy(other);
+        }
+
+        // Allows for moving an inplace_function object of the same type, but with a smaller buffer
+        // May throw any exception encountered by the constructor when moving the target object
+        // If OtherCapacity is greater than Capacity, a compile-time error is issued
+        template<size_t OtherCapacity, size_t OtherAlignment>
+        inplace_function(inplace_function<RetT(ArgsT...), OtherCapacity, OtherAlignment>&& other)
+        {
+            this->move(std::move(other));
+        }
+
+        // Copy assignment is not possible from uncopyable inplace_functions
+        inplace_function& operator=(const inplace_function& other) = delete;
 
         // Assigns the other’s target by way of moving
         // May throw any exception encountered by the assignment operator when moving the target object
@@ -296,7 +610,7 @@ namespace stdext
 
         using CompatibleFunctionPointer = RetT (*)(ArgsT...);
         using InvokeFctPtrType = RetT (*)(ArgsT..., const void* thisPtr);
-        using Operation = typename inplace_function_operation<Copyable>::operations_enum;
+        using Operation = inplace_function_operation::operations_enum;
         using ManagerFctPtrType = void (*)(void* thisPtr, const void* fromPtr, Operation);
 
         InvokeFctPtrType m_InvokeFctPtr;
@@ -339,7 +653,7 @@ namespace stdext
             new (buffer) FunctorT(ftor);
 
             // generate destructor, copy-constructor and move-constructor
-            m_ManagerFctPtr = &manage_function<FunctorT, Copyable>::call;
+            m_ManagerFctPtr = &manage_function<FunctorT>::call;
 
             // generate entry call
             m_InvokeFctPtr = &invoke<FunctorT>;
@@ -359,8 +673,8 @@ namespace stdext
             FunctorT* buffer = reinterpret_cast<FunctorT*>(&m_Data);
             new (buffer) FunctorT(std::move(ftor));
 
-            // generate destructor, copy-constructor and move-constructor
-            m_ManagerFctPtr = &manage_function<FunctorT, Copyable>::call;
+            // generate destructor and move-constructor
+            m_ManagerFctPtr = &manage_function<FunctorT>::call;
 
             // generate entry call
             m_InvokeFctPtr = &invoke<FunctorT>;
@@ -373,7 +687,7 @@ namespace stdext
             return (*functor)(std::forward<ArgsT>(args)...);
         }
 
-        template<typename FunctorT, bool SupportsCopying>
+        template<typename FunctorT>
         struct manage_function
         {
             static void call(void* dataPtr, const void* fromPtr, Operation op)
@@ -396,24 +710,6 @@ namespace stdext
                     {
                         assert(false && "Unexpected operation");
                     }
-                }
-            }
-        };
-
-        template<typename FunctorT>
-        struct manage_function<FunctorT, true>
-        {
-            static void call(void* dataPtr, const void* fromPtr, Operation op)
-            {
-                if (op == Operation::Copy)
-                {
-                    FunctorT* thisFunctor = reinterpret_cast<FunctorT*>(dataPtr);
-                    const FunctorT* source = (const FunctorT*)const_cast<void*>(fromPtr);
-                    new (thisFunctor) FunctorT(*source);
-                }
-                else
-                {
-                    manage_function<FunctorT, false>::call(dataPtr, fromPtr, op);
                 }
             }
         };

--- a/Source/Shared/arcana/threading/dispatcher.h
+++ b/Source/Shared/arcana/threading/dispatcher.h
@@ -15,7 +15,7 @@ namespace arcana
     class dispatcher
     {
     public:
-        using callback_t = stdext::inplace_function<void(), WorkSize>;
+        using callback_t = stdext::inplace_function<void(), WorkSize, alignof(std::max_align_t), false>;
         static constexpr size_t work_size = WorkSize;
 
         template<typename T>


### PR DESCRIPTION
Modified dispatcher.h to use uncopyable `inplace_function`s. This required some significant modification to the uncopyable features added to `inplace_function` previously, as that implementation had some serious flaws. In particular, while the implementation prevented copying and prevented the copy constructor from existing, it didn't actually *delete* the copy constructor. This meant that code which was simply looking to see whether uncopyable `inplace_function`s *had* a copy constructor -- notably `std::is_copy_constructible` -- to see that the copy constructor still existed and to conclude, therefore, that the type was copyable. This caused problems when it led MSVC's implementation of certain STL containers to elect to copy rather than move, only to fail when the copy constructor turned out to be unusable.

To solve this problem, the copy constructor needed to be deleted, not merely unusable; and to do that, the uncopyable version of the `inplace_function` needed to be a specialization of the entire type, not just of specific functions. Thus, `inplace_function.h` now contains two `inplace_function` specializations, one copyable and one not, with the shared behavior factored out as much as possible into a separate `impl`. With this change, `std::is_copy_constructible` is able to correctly determine the copyability of `inplace_function`s, leading MSVC's STL to make the right decisions and allowing us to use uncopyable `inplace_function`s in dispatcher.h.