### PR TITLE
Pinnable cancellations

### DIFF
--- a/Source/Shared/arcana/threading/cancellation.h
+++ b/Source/Shared/arcana/threading/cancellation.h
@@ -3,12 +3,10 @@
 #include "arcana/containers/ticketed_collection.h"
 
 #include <algorithm>
-#include <cassert>
 #include <atomic>
-#include <memory>
-#include <vector>
-
+#include <cassert>
 #include <functional>
+#include <memory>
 #include <vector>
 
 namespace arcana

--- a/Source/Shared/arcana/threading/cancellation.h
+++ b/Source/Shared/arcana/threading/cancellation.h
@@ -52,8 +52,8 @@ namespace arcana
                     std::unique_lock lock{ m_mutex };
                     m_condition.wait(lock, [this] { return m_pins == 0; });
 
-                    listeners.reserve(listeners.size());
-                    std::copy(listeners.begin(), listeners.end(), std::back_inserter(listeners));
+                    listeners.reserve(m_listeners.size());
+                    std::copy(m_listeners.begin(), m_listeners.end(), std::back_inserter(listeners));
                 }
 
                 // We want to signal cancellation in reverse order
@@ -61,7 +61,7 @@ namespace arcana
                 // then a child function does the same, the child
                 // cancellation runs first. This avoids ownership
                 // semantic issues.
-                for(auto itr = listeners.rbegin(); itr != listeners.rend(); ++itr)
+                for (auto itr = listeners.rbegin(); itr != listeners.rend(); ++itr)
                     (*itr)();
             }
 

--- a/Source/Shared/arcana/threading/cancellation.h
+++ b/Source/Shared/arcana/threading/cancellation.h
@@ -163,7 +163,7 @@ namespace arcana
     {
     public:
         cancellation_source()
-            : cancellation{ std::make_unique<internal::cancellation_impl>() }
+            : cancellation{ std::make_shared<internal::cancellation_impl>() }
         {
         }
 

--- a/Source/Shared/arcana/threading/internal/internal_task.h
+++ b/Source/Shared/arcana/threading/internal/internal_task.h
@@ -509,7 +509,7 @@ namespace arcana
             {
                 using traits = callable_traits<CallableT, InputT>;
 
-                return[callable = std::forward<CallableT>(callable), &cancel](const basic_expected<InputT, InputErrorT>& input) mutable noexcept
+                return[callable = std::forward<CallableT>(callable), cancel](const basic_expected<InputT, InputErrorT>& input) mutable noexcept
                 {
                     // Because the callable supports an expected<> input parameter
                     // we need to call it if the previous task fails. But if the task doesn't
@@ -531,7 +531,7 @@ namespace arcana
             {
                 using traits = callable_traits<CallableT, InputT>;
 
-                return[callable = std::forward<CallableT>(callable), &cancel](const basic_expected<InputT, InputErrorT>& input) mutable noexcept
+                return[callable = std::forward<CallableT>(callable), cancel](const basic_expected<InputT, InputErrorT>& input) mutable noexcept
                 {
                     // Here the callable doesn't handle expected<> which means we don't have to invoke
                     // it if the previous task error'd out or its cancellation token is set.
@@ -554,7 +554,7 @@ namespace arcana
             {
                 using traits = callable_traits<CallableT, void>;
 
-                return[callable = std::forward<CallableT>(callable), &cancel](const basic_expected<void, InputErrorT>& input) mutable noexcept
+                return[callable = std::forward<CallableT>(callable), cancel](const basic_expected<void, InputErrorT>& input) mutable noexcept
                 {
                     // Here the callable doesn't handle expected<> which means we don't have to invoke
                     // it if the previous task error'd out or its cancellation token is set.

--- a/Source/Shared/arcana/threading/internal/internal_task.h
+++ b/Source/Shared/arcana/threading/internal/internal_task.h
@@ -43,7 +43,7 @@ namespace arcana
             struct continuation_payload
             {
                 using queue_function = stdext::inplace_function<void(), 2 * sizeof(std::shared_ptr<void>)>;
-                using scheduling_function = stdext::inplace_function<void(queue_function&&), sizeof(intptr_t) + sizeof(cancellation)>;
+                using scheduling_function = stdext::inplace_function<void(queue_function&&), sizeof(intptr_t) + sizeof(intptr_t) + sizeof(cancellation)>;
 
                 explicit operator bool() const noexcept
                 {

--- a/Source/Shared/arcana/threading/task.h
+++ b/Source/Shared/arcana/threading/task.h
@@ -111,9 +111,13 @@ namespace arcana
                     })
             ) };
 
-            m_payload->create_continuation([&scheduler](auto&& c)
+            m_payload->create_continuation([&scheduler, token](auto&& c) mutable
             {
-                scheduler(std::forward<decltype(c)>(c));
+                auto cancel_pin = token.pin();
+                if (cancel_pin)
+                {
+                    scheduler(std::forward<decltype(c)>(c));
+                }
             }, m_payload, std::move(factory.to_run.m_payload));
 
             return factory.to_return;

--- a/Source/Shared/arcana/threading/task.h
+++ b/Source/Shared/arcana/threading/task.h
@@ -535,10 +535,10 @@ namespace arcana
     arcana::task<void, ErrorT> make_cancellation_task(cancellation_source& cancel)
     {
         task_completion_source<void, ErrorT> source{};
-        auto ticket = cancel.add_listener([source]() mutable {
+        auto ticket = cancel.add_cancellation_completed_listener([source]() mutable {
             source.complete();
         });
-        cancel.unsafe_cancel();
+        cancel.cancel();
         return source.as_task().then(inline_scheduler, cancellation::none(), [ticket{std::move(ticket)}]() {});
     }
 }

--- a/Source/Shared/arcana/threading/task.h
+++ b/Source/Shared/arcana/threading/task.h
@@ -285,6 +285,8 @@ namespace arcana
         using traits = internal::callable_traits<CallableT, void>;
         using wrapper = internal::input_output_wrapper<void, typename traits::error_propagation_type, false>;
 
+        // The cancel pin functions like a scope guard, so we take it here in order
+        // to guard the entire method, including the creation of the factory.
         auto cancel_pin = token.pin();
 
         auto factory{ internal::make_task_factory(

--- a/Source/Shared/arcana/threading/task.h
+++ b/Source/Shared/arcana/threading/task.h
@@ -284,10 +284,14 @@ namespace arcana
                 })
         ) };
 
-        scheduler([to_run = std::move(factory.to_run)]
+        auto cancel_pin = token.pin();
+        if (cancel_pin)
         {
-            to_run.m_payload->run(nullptr);
-        });
+            scheduler([to_run = std::move(factory.to_run)]
+            {
+                to_run.m_payload->run(nullptr);
+            });
+        }
 
         return factory.to_return;
     }


### PR DESCRIPTION
Changes the behavior of cancellation by making cancellation tokens "pin" the cancellation source under certain circumstances. Most importantly, cancellations get pinned while the work payload they are made to cancel is being executed. This makes cancelling a cancel source a blocking operation; a pinned cancellation source will block on cancel until it is unpinned. At the same time, cancelling *immediately* prevents any further pinning. The end result is that calling `cancel()` now means that no new work guarded by this cancellation can be started, but all work guarded by this cancellation will be finished before `cancel()` returns. This can be used, for example, to ensure that task can safely utilize resources without taking ownership of them. Suppose, for example, that a class `Foo` has a member variable `m_bar` and a cancellation source `m_cancelSource`. So long as `~Foo()` calls `m_cancelSource.cancel()` before it destructs `m_bar`, tasks run using `m_cancelSource` can safely use `m_bar` without worrying that it might be destructed by `Foo`'s lifecycle after the task has started but before the task completes.