### PR TITLE
Fix continuation running even if canceled

### DIFF
--- a/Source/Shared.Test/Threading/TaskUnitTest.cpp
+++ b/Source/Shared.Test/Threading/TaskUnitTest.cpp
@@ -769,6 +769,22 @@ namespace UnitTests
             Assert::AreEqual(2, hitCount);
         }
 
+        TEST_METHOD(CanceledExpectedContinuation)
+        {
+            arcana::cancellation_source cancel;
+            cancel.cancel();
+
+            bool wasCalled = false;
+
+            arcana::task_from_error<void>(std::errc::invalid_argument)
+                .then(arcana::inline_scheduler, cancel, [&](const arcana::expected<void, std::error_code>& value) noexcept
+                {
+                    wasCalled = true;
+                });
+
+            Assert::IsFalse(wasCalled, L"This method shouldn't run");
+        }
+
         TEST_METHOD(CancellationOrder_IsReverseOfOrderAdded)
         {
             arcana::cancellation_source root;

--- a/Source/Shared/arcana/threading/internal/internal_task.h
+++ b/Source/Shared/arcana/threading/internal/internal_task.h
@@ -511,11 +511,7 @@ namespace arcana
 
                 return[callable = std::forward<CallableT>(callable), &cancel](const basic_expected<InputT, InputErrorT>& input) mutable noexcept
                 {
-                    // Because the callable supports an expected<> input parameter
-                    // we need to call it if the previous task fails. But if the task doesn't
-                    // care about cancellation, and it's cancellation token is set then we
-                    // can just return the cancellation result directly.
-                    if (!input.has_error() && cancel.cancelled())
+                    if (cancel.cancelled())
                         return typename traits::expected_return_type{ make_unexpected(std::errc::operation_canceled) };
 
                     return output_wrapper<typename traits::return_type, typename traits::error_propagation_type>::invoke(callable, input);


### PR DESCRIPTION
Tested without the fix with just the unit test first to make sure it fails. Then tested with the fix to make sure it succeeded.