### PR TITLE
Add optional testing hook for blocking_concurrent_queue

### DIFF
--- a/Source/Shared/arcana/threading/blocking_concurrent_queue.h
+++ b/Source/Shared/arcana/threading/blocking_concurrent_queue.h
@@ -3,12 +3,37 @@
 #include "cancellation.h"
 
 #include <atomic>
+#include <condition_variable>
+#include <limits>
 #include <mutex>
 #include <queue>
-#include <condition_variable>
+#include <utility>
+#include <vector>
+
+#ifdef ARCANA_TESTING_HOOKS
+#include <functional>
+#endif
 
 namespace arcana
 {
+#ifdef ARCANA_TESTING_HOOKS
+    namespace detail
+    {
+        // Callback invoked while holding the queue mutex, right before
+        // condition_variable::wait(). Sleeping here widens the race window
+        // for lost-wakeup bugs: code that notifies without the mutex will
+        // lose the signal, while code that coordinates through push() (which
+        // acquires the mutex) will block until wait() is entered and then
+        // deliver the notification correctly.
+        inline std::function<void()> beforeWaitCallback{[]() {}};
+    }
+
+    inline void set_before_wait_callback(std::function<void()> callback)
+    {
+        detail::beforeWaitCallback = std::move(callback);
+    }
+#endif
+
     template<typename T, size_t max_size = std::numeric_limits<size_t>::max()>
     class blocking_concurrent_queue
     {
@@ -95,6 +120,9 @@ namespace arcana
             {
                 while (!cancel.cancelled() && m_data.empty())
                 {
+#ifdef ARCANA_TESTING_HOOKS
+                    detail::beforeWaitCallback();
+#endif
                     m_dataReady.wait(lock);
                 }
             }
@@ -116,6 +144,9 @@ namespace arcana
             {
                 while (!cancel.cancelled() && m_data.empty())
                 {
+#ifdef ARCANA_TESTING_HOOKS
+                    detail::beforeWaitCallback();
+#endif
                     m_dataReady.wait(lock);
                 }
             }

--- a/Source/Shared/arcana/threading/blocking_concurrent_queue.h
+++ b/Source/Shared/arcana/threading/blocking_concurrent_queue.h
@@ -19,12 +19,6 @@ namespace arcana
 #ifdef ARCANA_TESTING_HOOKS
     namespace detail
     {
-        // Callback invoked while holding the queue mutex, right before
-        // condition_variable::wait(). Sleeping here widens the race window
-        // for lost-wakeup bugs: code that notifies without the mutex will
-        // lose the signal, while code that coordinates through push() (which
-        // acquires the mutex) will block until wait() is entered and then
-        // deliver the notification correctly.
         inline std::function<void()> beforeWaitCallback{[]() {}};
     }
 

--- a/Source/Shared/arcana/threading/blocking_concurrent_queue.h
+++ b/Source/Shared/arcana/threading/blocking_concurrent_queue.h
@@ -28,6 +28,9 @@ namespace arcana
         inline std::function<void()> beforeWaitCallback{[]() {}};
     }
 
+    // Set a callback to be invoked while holding the queue mutex, right before
+    // condition_variable::wait(). This is used for deterministic testing of
+    // lost-wakeup race conditions. Pass an empty lambda [](){} to reset.
     inline void set_before_wait_callback(std::function<void()> callback)
     {
         detail::beforeWaitCallback = std::move(callback);


### PR DESCRIPTION
Add a global before-wait callback to blocking_concurrent_queue, invoked while holding the queue mutex right before condition_variable::wait().

## Motivation

This enables deterministic testing of lost-wakeup race conditions. By sleeping in the callback (while holding the mutex), a test can guarantee a worker thread is between the condition check and wait(). Code that coordinates through push() (which acquires the mutex) will block until the worker enters wait() and deliver the notification correctly. Code that uses bare notify_all() (without the mutex) will lose the signal.

## Changes

- blocking_concurrent_queue.h: global g_beforeWaitCallback (initialized to no-op), called before each wait()

All behind ARCANA_TESTING_HOOKS -- zero cost when not enabled. No other files changed.

## Usage

Used by BabylonJS/JsRuntimeHost#146 to deterministically reproduce a deadlock in AppRuntime shutdown.