### PR TITLE
Rename testing hooks for consistency and clarity

### DIFF
--- a/Source/Shared/arcana/threading/blocking_concurrent_queue.h
+++ b/Source/Shared/arcana/threading/blocking_concurrent_queue.h
@@ -17,7 +17,7 @@
 namespace arcana
 {
 #ifdef ARCANA_TESTING_HOOKS
-    namespace test_hooks::dispatcher
+    namespace test_hooks::blocking_concurrent_queue
     {
         namespace detail
         {
@@ -121,7 +121,7 @@ namespace arcana
                 while (!cancel.cancelled() && m_data.empty())
                 {
 #ifdef ARCANA_TESTING_HOOKS
-                    test_hooks::dispatcher::detail::beforeWaitCallback();
+                    test_hooks::blocking_concurrent_queue::detail::beforeWaitCallback();
 #endif
                     m_dataReady.wait(lock);
                 }
@@ -145,7 +145,7 @@ namespace arcana
                 while (!cancel.cancelled() && m_data.empty())
                 {
 #ifdef ARCANA_TESTING_HOOKS
-                    test_hooks::dispatcher::detail::beforeWaitCallback();
+                    test_hooks::blocking_concurrent_queue::detail::beforeWaitCallback();
 #endif
                     m_dataReady.wait(lock);
                 }

--- a/Source/Shared/arcana/threading/blocking_concurrent_queue.h
+++ b/Source/Shared/arcana/threading/blocking_concurrent_queue.h
@@ -17,17 +17,20 @@
 namespace arcana
 {
 #ifdef ARCANA_TESTING_HOOKS
-    namespace detail
+    namespace test_hooks::dispatcher
     {
-        inline std::function<void()> beforeWaitCallback{[]() {}};
-    }
+        namespace detail
+        {
+            inline std::function<void()> beforeWaitCallback{[]() {}};
+        }
 
-    // Set a callback to be invoked while holding the queue mutex, right before
-    // condition_variable::wait(). This is used for deterministic testing of
-    // lost-wakeup race conditions. Pass an empty lambda [](){} to reset.
-    inline void set_before_wait_callback(std::function<void()> callback)
-    {
-        detail::beforeWaitCallback = std::move(callback);
+        // Set a callback to be invoked while holding the queue mutex, right before
+        // condition_variable::wait(). This is used for deterministic testing of
+        // lost-wakeup race conditions. Pass an empty lambda [](){} to reset.
+        inline void set_before_wait_callback(std::function<void()> callback)
+        {
+            detail::beforeWaitCallback = std::move(callback);
+        }
     }
 #endif
 
@@ -118,7 +121,7 @@ namespace arcana
                 while (!cancel.cancelled() && m_data.empty())
                 {
 #ifdef ARCANA_TESTING_HOOKS
-                    detail::beforeWaitCallback();
+                    test_hooks::dispatcher::detail::beforeWaitCallback();
 #endif
                     m_dataReady.wait(lock);
                 }
@@ -142,7 +145,7 @@ namespace arcana
                 while (!cancel.cancelled() && m_data.empty())
                 {
 #ifdef ARCANA_TESTING_HOOKS
-                    detail::beforeWaitCallback();
+                    test_hooks::dispatcher::detail::beforeWaitCallback();
 #endif
                     m_dataReady.wait(lock);
                 }

--- a/Source/Shared/arcana/threading/blocking_concurrent_queue.h
+++ b/Source/Shared/arcana/threading/blocking_concurrent_queue.h
@@ -10,13 +10,13 @@
 #include <utility>
 #include <vector>
 
-#ifdef ARCANA_TESTING_HOOKS
+#ifdef ARCANA_TEST_HOOKS
 #include <functional>
 #endif
 
 namespace arcana
 {
-#ifdef ARCANA_TESTING_HOOKS
+#ifdef ARCANA_TEST_HOOKS
     namespace test_hooks::blocking_concurrent_queue
     {
         namespace detail
@@ -120,7 +120,7 @@ namespace arcana
             {
                 while (!cancel.cancelled() && m_data.empty())
                 {
-#ifdef ARCANA_TESTING_HOOKS
+#ifdef ARCANA_TEST_HOOKS
                     test_hooks::blocking_concurrent_queue::detail::beforeWaitCallback();
 #endif
                     m_dataReady.wait(lock);
@@ -144,7 +144,7 @@ namespace arcana
             {
                 while (!cancel.cancelled() && m_data.empty())
                 {
-#ifdef ARCANA_TESTING_HOOKS
+#ifdef ARCANA_TEST_HOOKS
                     test_hooks::blocking_concurrent_queue::detail::beforeWaitCallback();
 #endif
                     m_dataReady.wait(lock);


### PR DESCRIPTION
Rename testing hooks for consistency and clarity.

## Changes

- Rename macro `ARCANA_TESTING_HOOKS` to `ARCANA_TEST_HOOKS` to match the `test_hooks` namespace
- Move hooks from `arcana::detail` / `arcana::set_before_wait_callback` to `arcana::test_hooks::blocking_concurrent_queue` namespace, accurately reflecting where the hook fires

Consumer call changes from:
```cpp
#ifdef ARCANA_TESTING_HOOKS
arcana::set_before_wait_callback(...);
```
to:
```cpp
#ifdef ARCANA_TEST_HOOKS
arcana::test_hooks::blocking_concurrent_queue::set_before_wait_callback(...);
```