### PR TITLE
Protect test hook callback with mutex for TSan safety

### DIFF
--- a/Source/Shared/arcana/threading/blocking_concurrent_queue.h
+++ b/Source/Shared/arcana/threading/blocking_concurrent_queue.h
@@ -23,6 +23,18 @@ namespace arcana
         {
             inline std::mutex callbackMutex;
             inline std::function<void()> beforeWaitCallback{[]() {}};
+
+            // Copy the callback under the lock and invoke after releasing, avoiding
+            // potential deadlocks if the callback interacts with other locks.
+            inline void invoke_before_wait_callback()
+            {
+                std::function<void()> cb;
+                {
+                    std::lock_guard<std::mutex> lock{callbackMutex};
+                    cb = beforeWaitCallback;
+                }
+                cb();
+            }
         }
 
         // Set a callback to be invoked while holding the queue mutex, right before
@@ -123,14 +135,7 @@ namespace arcana
                 while (!cancel.cancelled() && m_data.empty())
                 {
 #ifdef ARCANA_TEST_HOOKS
-                    {
-                        std::function<void()> cb;
-                        {
-                            std::lock_guard<std::mutex> cbLock{test_hooks::blocking_concurrent_queue::detail::callbackMutex};
-                            cb = test_hooks::blocking_concurrent_queue::detail::beforeWaitCallback;
-                        }
-                        cb();
-                    }
+                    test_hooks::blocking_concurrent_queue::detail::invoke_before_wait_callback();
 #endif
                     m_dataReady.wait(lock);
                 }
@@ -154,14 +159,7 @@ namespace arcana
                 while (!cancel.cancelled() && m_data.empty())
                 {
 #ifdef ARCANA_TEST_HOOKS
-                    {
-                        std::function<void()> cb;
-                        {
-                            std::lock_guard<std::mutex> cbLock{test_hooks::blocking_concurrent_queue::detail::callbackMutex};
-                            cb = test_hooks::blocking_concurrent_queue::detail::beforeWaitCallback;
-                        }
-                        cb();
-                    }
+                    test_hooks::blocking_concurrent_queue::detail::invoke_before_wait_callback();
 #endif
                     m_dataReady.wait(lock);
                 }

--- a/Source/Shared/arcana/threading/blocking_concurrent_queue.h
+++ b/Source/Shared/arcana/threading/blocking_concurrent_queue.h
@@ -21,6 +21,7 @@ namespace arcana
     {
         namespace detail
         {
+            inline std::mutex callbackMutex;
             inline std::function<void()> beforeWaitCallback{[]() {}};
         }
 
@@ -29,6 +30,7 @@ namespace arcana
         // lost-wakeup race conditions. Pass an empty lambda [](){} to reset.
         inline void set_before_wait_callback(std::function<void()> callback)
         {
+            std::lock_guard<std::mutex> lock{detail::callbackMutex};
             detail::beforeWaitCallback = std::move(callback);
         }
     }
@@ -121,7 +123,14 @@ namespace arcana
                 while (!cancel.cancelled() && m_data.empty())
                 {
 #ifdef ARCANA_TEST_HOOKS
-                    test_hooks::blocking_concurrent_queue::detail::beforeWaitCallback();
+                    {
+                        std::function<void()> cb;
+                        {
+                            std::lock_guard<std::mutex> cbLock{test_hooks::blocking_concurrent_queue::detail::callbackMutex};
+                            cb = test_hooks::blocking_concurrent_queue::detail::beforeWaitCallback;
+                        }
+                        cb();
+                    }
 #endif
                     m_dataReady.wait(lock);
                 }
@@ -145,7 +154,14 @@ namespace arcana
                 while (!cancel.cancelled() && m_data.empty())
                 {
 #ifdef ARCANA_TEST_HOOKS
-                    test_hooks::blocking_concurrent_queue::detail::beforeWaitCallback();
+                    {
+                        std::function<void()> cb;
+                        {
+                            std::lock_guard<std::mutex> cbLock{test_hooks::blocking_concurrent_queue::detail::callbackMutex};
+                            cb = test_hooks::blocking_concurrent_queue::detail::beforeWaitCallback;
+                        }
+                        cb();
+                    }
 #endif
                     m_dataReady.wait(lock);
                 }


### PR DESCRIPTION
[Created by Copilot on behalf of @bghgary]

Protect the `beforeWaitCallback` test hook with a mutex for TSan safety.

## Problem

The `beforeWaitCallback` global in `blocking_concurrent_queue` was unprotected — one thread could be reading/invoking it while another called `set_before_wait_callback`. TSan flags this as a data race.

## Fix

- Add `callbackMutex` to guard `beforeWaitCallback` access
- `set_before_wait_callback`: acquires lock, moves new callback in
- `invoke_before_wait_callback` (new `detail` helper): copies callback under the lock, invokes after releasing — avoids potential deadlocks if the callback interacts with other locks
- Both `internal_pop` and `internal_drain` call the helper instead of inlining the pattern
