### PR TITLE
Add a ci-complete gate job and bound job runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,12 +102,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        # Bound apt's own retries and transfer timeouts. When the in-datacenter
-        # mirror is degraded, apt otherwise falls back to archive.ubuntu.com and
-        # can stall there silently for hours: actions/runner-images#14594
-        APT_OPTS="-o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10"
-        sudo apt-get update $APT_OPTS
-        sudo apt-get install -y $APT_OPTS ${{ matrix.packages }}
+        sudo apt-get update
+        sudo apt-get install -y ${{ matrix.packages }}
 
     - name: Configure CMake
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
   windows:
     name: Windows
     runs-on: windows-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         config: [Debug, Release]
@@ -34,6 +35,7 @@ jobs:
   macos:
     name: macOS
     runs-on: macos-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         config: [Debug, Release]
@@ -58,6 +60,7 @@ jobs:
   ios:
     name: iOS
     runs-on: macos-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         config: [Debug, Release]
@@ -78,6 +81,7 @@ jobs:
   linux:
     name: Linux
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         config: [Debug, Release]
@@ -86,17 +90,24 @@ jobs:
           - compiler: gcc-11
             cc: gcc-11
             cxx: g++-11
+            packages: gcc-11 g++-11
           - compiler: clang-14
             cc: clang-14
             cxx: clang++-14
+            # clang-14 ships the clang++-14 binary; there is no clang++-14 package
+            packages: clang-14
 
     steps:
     - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
     - name: Install dependencies
       run: |
-        sudo apt-get update
-        sudo apt-get install -y ${{ matrix.cc }} ${{ matrix.cxx }}
+        # Bound apt's own retries and transfer timeouts. When the in-datacenter
+        # mirror is degraded, apt otherwise falls back to archive.ubuntu.com and
+        # can stall there silently for hours: actions/runner-images#14594
+        APT_OPTS="-o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10"
+        sudo apt-get update $APT_OPTS
+        sudo apt-get install -y $APT_OPTS ${{ matrix.packages }}
 
     - name: Configure CMake
       run: |
@@ -115,3 +126,30 @@ jobs:
     #   working-directory: Build
     #   run: |
     #     ctest -C ${{ matrix.config }} --output-on-failure --verbose
+
+  ci-complete:
+    name: ci-complete
+    # Single aggregate check for branch protection to require, so the 14
+    # matrix-generated check names stay free to change.
+    #
+    # `if: always()` is load-bearing: without it this job is skipped whenever a
+    # dependency fails, and a skipped required check satisfies the requirement --
+    # inverting the gate. The step below then asserts every result is success, so
+    # failed, cancelled and skipped dependencies all fail the gate.
+    if: always()
+    needs: [windows, macos, ios, linux]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+    - name: Verify all jobs succeeded
+      env:
+        RESULTS: ${{ join(needs.*.result, ' ') }}
+      run: |
+        echo "Job results: $RESULTS"
+        for result in $RESULTS; do
+          if [ "$result" != "success" ]; then
+            echo "::error::CI did not succeed (results: $RESULTS)"
+            exit 1
+          fi
+        done


### PR DESCRIPTION
[Created by Copilot on behalf of @bghgary]

## Context

`master` requires no status checks, so an approval alone can merge a PR whose CI is red or never ran. Requiring the current checks as-is is not viable: all 14 names are matrix-generated, so any matrix edit strands a required check that never reports and leaves PRs blocked with no visible cause. `ci-complete` is one stable name to require instead.

`timeout-minutes` is a precondition for that, not a separate cleanup. Three Linux jobs hung for ~6h on 19 August with no output at all before the 360-minute default timeout ([actions/runner-images#14594](https://github.com/actions/runner-images/issues/14594)). Once a check is required, an unbounded hang is not a slow build — it is an unmergeable PR with no failure to act on.

## Worth a look

- **`if: always()` on `ci-complete` is load-bearing.** Without it the job is *skipped* when a dependency fails, and a skipped required check satisfies the requirement — inverting the gate. Two workflows differing only in that line produced `skipped` against `failure`.
- **The assertion is positive** — every entry of `needs.*.result` must equal `success` — so a result value we have not anticipated fails closed rather than passing through.
- **`clang++-14` is not a package name.** apt fell through to regex matching and installed 20 packages instead of 2, including `clang-14-doc` and `clang-14-examples`; `clang-14` alone ships the `clang++-14` binary. `cxx` still feeds CMake, so the install list moves to a separate `packages` key.
- **No apt workaround here, deliberately.** The runner image sets `APT::Acquire::Retries "10"`; overriding it would trade resilience against ordinary transient failures for a faster fail in one case, and the root cause is fixed image-side by [actions/runner-images#14596](https://github.com/actions/runner-images/pull/14596).

## Follow-up

Once `ci-complete` has reported here at least once, it can be added to `master`'s required status checks.
